### PR TITLE
成功修復 TextGraphics 類 include gamecore.h 發生編譯錯誤 ISSUE

### DIFF
--- a/Source/Game/Raiden/TextGraphics/TextGraphics.cpp
+++ b/Source/Game/Raiden/TextGraphics/TextGraphics.cpp
@@ -1,11 +1,17 @@
+#pragma once
 #include <StdAfx.h>
 #include "TextGraphics.h"
 #include <string>
-
+#include <ddraw.h>
+#include "../../../Library/gameutil.h"
+#include "../../../Library/gamecore.h"
 namespace Raiden
 {
 	void TextGraphics::Write(int left, int top, std::string text)
 	{
-		// TODO: write the logic of displaying texts.
+		CDC *p_dc = game_framework::CDDraw::GetBackCDC();
+		game_framework::CTextDraw::ChangeFontLog(p_dc, 30, "Times New Roman", RGB(255, 255, 255));
+		game_framework::CTextDraw::Print(p_dc, left, top, text);
+		game_framework::CDDraw::ReleaseBackCDC();
 	}
 }

--- a/Source/Game/mygame.h
+++ b/Source/Game/mygame.h
@@ -104,6 +104,7 @@ namespace game_framework {
 		Raiden::Manager manager;
 		std::map<UINT, Raiden::Key> keyMap;
 		std::set<Raiden::Key> keys;
+		Raiden::TextGraphics text_graphics;
 	};
 
 	/////////////////////////////////////////////////////////////////////////////

--- a/Source/Game/mygame_run.cpp
+++ b/Source/Game/mygame_run.cpp
@@ -35,6 +35,7 @@ void CGameStateRun::OnMove()							// 移動遊戲元素
 
 void CGameStateRun::OnInit()  								// 遊戲的初值及圖形設定
 {
+
 	//Raiden::GameObjectPool<int> test;
 	//test.AddElement({ 10,10 });
 	bullet.AddElement({ 50,50 });
@@ -87,4 +88,5 @@ void CGameStateRun::OnShow()
 		std::wstring info = L"collison";
 		OutputDebugStringW(info.c_str());
 	}
+	text_graphics.Write(50,50,"FUCK You");
 }


### PR DESCRIPTION
#pragma once
#include <StdAfx.h>
#include "TextGraphics.h"
#include <string>
#include <ddraw.h>
#include "../../../Library/gameutil.h"
#include "../../../Library/gamecore.h"
namespace Raiden
{
	void TextGraphics::Write(int left, int top, std::string text)
	{
		CDC *p_dc = game_framework::CDDraw::GetBackCDC();
		game_framework::CTextDraw::ChangeFontLog(p_dc, 30, "Times New Roman", RGB(255, 255, 255));
		game_framework::CTextDraw::Print(p_dc, left, top, text);
		game_framework::CDDraw::ReleaseBackCDC();
	}
}
